### PR TITLE
change-id-size

### DIFF
--- a/cert/errors.go
+++ b/cert/errors.go
@@ -17,7 +17,6 @@ func mapToCertError(err error) error {
 		return nil
 	}
 
-	// Returned error cannot be unwrapped, compare strings
 	if err.Error() == "cipher: message authentication failed" {
 		return ErrCipherMsgAuthFailed
 	}


### PR DESCRIPTION
Adds mapToCertError tests.
Changes Certificate's ID and SignerID to unit64.
Changes public key field name `cert.Der` to `cert.PublicKey`.